### PR TITLE
Pascal/error occurrence field

### DIFF
--- a/packages/api/src/queries.graphql
+++ b/packages/api/src/queries.graphql
@@ -71,6 +71,7 @@ query Node($id: ID!) {
       name
     }
     basicAuth
+    erroredAt
   }
 }
 

--- a/packages/api/src/queries.graphql
+++ b/packages/api/src/queries.graphql
@@ -110,6 +110,7 @@ query Nodes {
       name
     }
     basicAuth
+    erroredAt
   }
 }
 

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -76,6 +76,7 @@ const typeDefs = gql`
     dispatch: Boolean
     basicAuth: String
     deltaArray: [Int]
+    erroredAt: String
   }
 
   type ServerCount {

--- a/packages/core/globalConfig.json
+++ b/packages/core/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:41189/","mongoDBName":"jest"}
+{"mongoUri":"mongodb://127.0.0.1:35623/","mongoDBName":"jest"}

--- a/packages/core/src/models/nodes.ts
+++ b/packages/core/src/models/nodes.ts
@@ -22,6 +22,7 @@ export interface INode<Populated = true> {
   automation?: boolean;
   dispatch?: boolean;
   deltaArray?: number[];
+  erroredAt: string;
 }
 
 export const nodesSchema = new Schema<INode>(
@@ -50,6 +51,7 @@ export const nodesSchema = new Schema<INode>(
     automation: Boolean,
     dispatch: Boolean,
     deltaArray: [Number],
+    erroredAt: Date,
   },
   { timestamps: true },
 );

--- a/packages/core/src/services/alert/alert.test.ts
+++ b/packages/core/src/services/alert/alert.test.ts
@@ -1,0 +1,49 @@
+import { Service } from './service';
+import { EAlertTypes } from '../event/types';
+
+const alertService = new Service();
+
+describe('Alert Service Tests', () => {
+  describe('getErrorTimeElapsedString', () => {
+    test('Should return a string for an error event that occurred over a minute ago', async () => {
+      const overAMinuteAgo = new Date(Date.now() - 1000 * 75).toUTCString();
+
+      const messageString = alertService['getErrorTimeElapsedString'](
+        overAMinuteAgo,
+        EAlertTypes.TRIGGER,
+      );
+
+      expect(messageString).toContain(
+        `Error has been occurring for 1 minute, 15 seconds`,
+      );
+    });
+
+    test('Should return a string for an error event that occurred less than a minute ago', async () => {
+      const lessThanMinuteAgo = new Date(Date.now() - 1000 * 45).toUTCString();
+
+      const messageString = alertService['getErrorTimeElapsedString'](
+        lessThanMinuteAgo,
+        EAlertTypes.TRIGGER,
+      );
+
+      const [firstOccurrence, elapsed] = messageString.split('\n');
+      expect(messageString).toContain(`First occurrence of this error was`);
+      expect(firstOccurrence).toBeTruthy();
+      expect(elapsed).toBeFalsy();
+    });
+
+    test('Should return a string for a resolved event', async () => {
+      const lessThanMinuteAgo = new Date(Date.now() - 1000 * 90).toUTCString();
+
+      const messageString = alertService['getErrorTimeElapsedString'](
+        lessThanMinuteAgo,
+        EAlertTypes.RESOLVED,
+      );
+
+      expect(messageString).toContain(`First occurrence of this error was`);
+      expect(messageString).toContain(
+        `Error had been occurring for 1 minute, 30 seconds`,
+      );
+    });
+  });
+});

--- a/packages/core/src/services/alert/service.ts
+++ b/packages/core/src/services/alert/service.ts
@@ -251,8 +251,8 @@ export class Service {
       return 'Delta is stuck.';
     }
 
-    const minutesToRecover = Math.floor(secondsToRecover / 60);
-    return `Node is syncing; the estimated time to sync is approximately ${minutesToRecover} minutes.`;
+    const timeToRecover = secondsToUnits(secondsToRecover);
+    return `Node is syncing; the estimated time to sync is approximately ${timeToRecover}.`;
   }
 
   getRotationMessage(

--- a/packages/core/src/services/alert/service.ts
+++ b/packages/core/src/services/alert/service.ts
@@ -4,7 +4,7 @@ import { api as pagerDutyApi } from '@pagerduty/pdjs';
 
 import { INode, IWebhook, WebhookModel } from '../../models';
 import { AlertTypes } from '../../types';
-import { colorLog, s, is } from '../../utils';
+import { colorLog, is, s, secondsToUnits } from '../../utils';
 import {
   AlertColor,
   SendMessageInput,
@@ -177,11 +177,12 @@ export class Service {
 
   /* ----- Message String Methods ----- */
   getAlertMessage(
-    { count, conditions, name, height, details }: IRedisEvent,
+    { conditions, name, height, details }: IRedisEvent,
     alertType: EAlertTypes,
     nodesOnline: number,
     nodesTotal: number,
     destination: string,
+    erroredAt?: string,
   ): { message: string; statusStr: string } {
     const badOracles = details?.badOracles?.join('\n');
     const noOracle = details?.noOracle;
@@ -189,10 +190,9 @@ export class Service {
     const secondsToRecover = details?.secondsToRecover;
 
     const statusStr = `${name} is ${conditions}.`;
-    const countStr =
-      alertType !== EAlertTypes.RESOLVED
-        ? `This event has occurred ${count} time${s(count)} since first occurrence.`
-        : '';
+    const countStr = erroredAt
+      ? this.getErrorTimeElapsedString(erroredAt, alertType)
+      : '';
     const heightStr = height
       ? `Block Height - Internal: ${height.internalHeight} / External: ${height.externalHeight} / Delta: ${height.delta}`
       : '';
@@ -229,6 +229,18 @@ export class Service {
         .join('\n'),
       statusStr,
     };
+  }
+
+  private getErrorTimeElapsedString(erroredAt: string, alertType: EAlertTypes): string {
+    const erroredDate = new Date(erroredAt);
+    const firstOccurrence = erroredDate.toUTCString();
+    const seconds = (new Date(Date.now()).getTime() - erroredDate.getTime()) / 1000;
+    const desc = alertType === EAlertTypes.RESOLVED ? 'had' : 'has';
+
+    const firstString = `First occurrence of this error was: ${firstOccurrence}.`;
+    const elapsedString =
+      seconds > 60 ? `\nError ${desc} been occurring for ${secondsToUnits(seconds)}` : '';
+    return `${firstString}${elapsedString}`;
   }
 
   private getSecondsToRecoverString(secondsToRecover: number): string {

--- a/packages/core/src/services/event/event.test.ts
+++ b/packages/core/src/services/event/event.test.ts
@@ -1,0 +1,146 @@
+import mongoose from 'mongoose';
+import { EErrorConditions, EErrorStatus } from '../health/types';
+import { ChainsModel, HostsModel, LocationsModel, NodesModel, INode } from '../../models';
+import { Service } from './service';
+import { EAlertTypes } from './types';
+
+const eventService = new Service();
+let node: INode;
+
+const createMocks = async () => {
+  const mockChain = {
+    name: 'POKT',
+    type: 'POKT',
+    allowance: 5,
+    chainId: '0666',
+    hasOwnEndpoint: true,
+    useOracles: false,
+    responsePath: 'data.result.healthy',
+  };
+  const chain = await ChainsModel.create(mockChain);
+  const mockLocation = { name: 'USE2' };
+  const location = await LocationsModel.create(mockLocation);
+  const mockHost = {
+    name: 'mainnet1',
+    loadBalancer: false,
+    location: location.id,
+    ip: '12.34.56.0',
+  };
+  const host = await HostsModel.create(mockHost);
+  const mockNode = {
+    name: 'mainnet1/POKT/11',
+    chain: chain.id,
+    host: host.id,
+    port: 8810,
+    url: `http://${host.ip}:8810`,
+    loadBalancers: [host.id],
+    backend: 'testpoktmainnet',
+    server: '2a',
+    automation: true,
+  };
+  const node = await NodesModel.create(mockNode);
+  return { chain, location, host, node };
+};
+let exampleEventJson: string;
+
+beforeAll(async () => {
+  await mongoose.connect(global.__MONGO_URI__);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+});
+
+describe('Event Service Tests', () => {
+  describe('parseEvent', () => {
+    beforeAll(async () => {
+      ({ node } = await createMocks());
+      exampleEventJson = JSON.stringify({
+        name: 'mainnet1/POKT/11',
+        status: EErrorStatus.OK,
+        conditions: EErrorConditions.HEALTHY,
+        health: 'Node is healthy.',
+        height: { internalHeight: 63583, externalHeight: 63583, delta: 0 },
+        id: node.id.toString(),
+      });
+    });
+
+    test('Should parse an incoming RESOLVED event', async () => {
+      const overAMinuteAgo = new Date(Date.now() - 1000 * 75).toUTCString();
+      await NodesModel.updateOne({ _id: node.id }, { erroredAt: overAMinuteAgo });
+
+      jest
+        .spyOn(eventService as any, 'getServerCount')
+        .mockImplementation(() => ({ online: 1, total: 1 }));
+
+      const {
+        node: createdNode,
+        title,
+        message,
+        healthy,
+        notSynced,
+        status,
+        nodesOnline,
+        nodesTotal,
+        dispatchFrontendDown,
+      } = await eventService['parseEvent'](exampleEventJson, EAlertTypes.RESOLVED);
+      const nodeAfter = await NodesModel.findOne({ _id: node.id });
+
+      expect(createdNode.name).toEqual('mainnet1/POKT/11');
+      expect(title).toEqual('[Resolved] - mainnet1/POKT/11 is HEALTHY.');
+      expect(message).toContain('First occurrence of this error was');
+      expect(message).toContain('Error had been occurring for 1 minute, 15 seconds');
+      expect(message).toContain(
+        'Block Height - Internal: 63583 / External: 63583 / Delta: 0',
+      );
+      expect(message).toContain('1 OF 1 NODE IS IN ROTATION FOR TESTPOKTMAINNET.');
+      expect(healthy).toEqual(true);
+      expect(notSynced).toEqual(false);
+      expect(status).toEqual('OK');
+      expect(nodesOnline).toEqual(1);
+      expect(nodesTotal).toEqual(1);
+      expect(dispatchFrontendDown).toEqual(false);
+      expect(nodeAfter.erroredAt).toBeFalsy();
+    });
+
+    test('Should parse an incoming TRIGGERED event', async () => {
+      jest
+        .spyOn(eventService as any, 'getServerCount')
+        .mockImplementation(() => ({ online: 0, total: 1 }));
+      exampleEventJson = JSON.stringify({
+        ...JSON.parse(exampleEventJson),
+        status: EErrorStatus.ERROR,
+        conditions: EErrorConditions.NOT_SYNCHRONIZED,
+      });
+
+      const {
+        node,
+        title,
+        message,
+        healthy,
+        notSynced,
+        status,
+        nodesOnline,
+        nodesTotal,
+        dispatchFrontendDown,
+      } = await eventService['parseEvent'](exampleEventJson, EAlertTypes.TRIGGER);
+
+      expect(node.name).toEqual('mainnet1/POKT/11');
+      expect(node.erroredAt).toBeTruthy();
+      expect(title).toEqual('[Triggered] - mainnet1/POKT/11 is NOT_SYNCHRONIZED.');
+
+      expect(message).toContain('First occurrence of this error was');
+      expect(message).not.toContain('Error has been occurring for');
+      expect(message).toContain(
+        'Block Height - Internal: 63583 / External: 63583 / Delta: 0',
+      );
+      expect(message).toContain('0 OF 1 NODE IS IN ROTATION FOR TESTPOKTMAINNET.');
+      expect(healthy).toEqual(false);
+      expect(notSynced).toEqual(true);
+      expect(status).toEqual('ERROR');
+      expect(nodesOnline).toEqual(0);
+      expect(nodesTotal).toEqual(1);
+      expect(dispatchFrontendDown).toEqual(false);
+    });
+  });
+});

--- a/packages/core/src/services/event/types.ts
+++ b/packages/core/src/services/event/types.ts
@@ -7,7 +7,6 @@ import { HealthTypes } from '../../types';
 
 export interface IRedisEvent extends HealthTypes.IHealthResponse {
   id: string;
-  count: number;
 }
 
 export interface IRotationParams {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -58,9 +58,9 @@ export function secondsToUnits(seconds: number): string {
   const m = Math.floor((seconds % 3600) / 60);
   const s = Math.floor(seconds % 60);
 
-  const dDisplay = d > 0 ? d + (d == 1 ? ' day, ' : ' days, ') : '';
-  const hDisplay = h > 0 ? h + (h == 1 ? ' hour, ' : ' hours, ') : '';
-  const mDisplay = m > 0 ? m + (m == 1 ? ' minute, ' : ' minutes, ') : '';
-  const sDisplay = s > 0 ? s + (s == 1 ? ' second' : ' seconds') : '';
+  const dDisplay = d > 0 ? d + (d === 1 ? ' day, ' : ' days, ') : '';
+  const hDisplay = h > 0 ? h + (h === 1 ? ' hour, ' : ' hours, ') : '';
+  const mDisplay = m > 0 ? m + (m === 1 ? ' minute, ' : ' minutes, ') : '';
+  const sDisplay = s > 0 ? s + (s === 1 ? ' second' : ' seconds') : '';
   return dDisplay + hDisplay + mDisplay + sDisplay;
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -50,3 +50,17 @@ export function shuffle(array: any[]): any[] {
 
   return array;
 }
+
+export function secondsToUnits(seconds: number): string {
+  seconds = Number(seconds);
+  const d = Math.floor(seconds / (3600 * 24));
+  const h = Math.floor((seconds % (3600 * 24)) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+
+  const dDisplay = d > 0 ? d + (d == 1 ? ' day, ' : ' days, ') : '';
+  const hDisplay = h > 0 ? h + (h == 1 ? ' hour, ' : ' hours, ') : '';
+  const mDisplay = m > 0 ? m + (m == 1 ? ' minute, ' : ' minutes, ') : '';
+  const sDisplay = s > 0 ? s + (s == 1 ? ' second' : ' seconds') : '';
+  return dDisplay + hDisplay + mDisplay + sDisplay;
+}

--- a/packages/monitor/src/publish.ts
+++ b/packages/monitor/src/publish.ts
@@ -40,7 +40,7 @@ export class Publish {
         : this.map.set(id, 1);
       const count = this.map.get(id);
 
-      const event: EventTypes.IRedisEvent = { ...message, id, count };
+      const event: EventTypes.IRedisEvent = { ...message, id };
       if (count === this.threshold) {
         await this.redis.publish('send-event-trigger', JSON.stringify(event));
       }
@@ -57,7 +57,7 @@ export class Publish {
         this.map.delete(id);
 
         if (count >= this.threshold) {
-          const event: EventTypes.IRedisEvent = { ...message, id, count };
+          const event: EventTypes.IRedisEvent = { ...message, id };
           await this.redis.publish('send-event-resolved', JSON.stringify(event));
         }
       }

--- a/packages/ui/src/components/Nodes/NodeHealth.tsx
+++ b/packages/ui/src/components/Nodes/NodeHealth.tsx
@@ -5,7 +5,7 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
 import { INode, IGetHealthCheckQuery, IGetServerCountQuery } from 'types';
-import { formatHeaderCell, numWithCommas, s } from 'utils';
+import { formatHeaderCell, getSeconds, numWithCommas, parseSeconds, s } from 'utils';
 
 interface NodeHealthProps {
   node: INode;
@@ -169,9 +169,7 @@ export const NodeHealth = ({
                   } else if (value === 0) {
                     displayValue = 'Delta is stuck';
                   } else {
-                    displayValue = `< ${numWithCommas(
-                      Math.floor(Number(value) / 60),
-                    )} minute${s(Math.floor(Number(value) / 60))}`;
+                    displayValue = `< ${parseSeconds(value as number)}`;
                   }
                 } else {
                   displayValue = value.toString();
@@ -192,6 +190,13 @@ export const NodeHealth = ({
               <Typography>
                 {healthCheckData.healthCheck.details.badOracles.join(', ')}
               </Typography>
+            </Box>
+          )}
+
+          {node.erroredAt && (
+            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Typography>Error Duration</Typography>
+              <Typography>{parseSeconds(getSeconds(node.erroredAt))}</Typography>
             </Box>
           )}
         </>

--- a/packages/ui/src/types/types.ts
+++ b/packages/ui/src/types/types.ts
@@ -540,7 +540,7 @@ export type INodeQueryVariables = Exact<{
 }>;
 
 
-export type INodeQuery = { node: { id: string, backend?: string | null, frontend?: string | null, port: number, name: string, server?: string | null, url: string, muted: boolean, status: string, conditions: string, automation?: boolean | null, dispatch?: boolean | null, basicAuth?: string | null, loadBalancers?: Array<{ id: string, name: string }> | null, chain: { id: string, name: string, type: string, allowance: number, chainId: string, hasOwnEndpoint: boolean, useOracles: boolean, responsePath: string, rpc?: string | null, endpoint?: string | null, healthyValue?: string | null }, host: { id: string, name: string } } };
+export type INodeQuery = { node: { id: string, backend?: string | null, frontend?: string | null, port: number, name: string, server?: string | null, url: string, muted: boolean, status: string, conditions: string, automation?: boolean | null, dispatch?: boolean | null, basicAuth?: string | null, erroredAt?: string | null, loadBalancers?: Array<{ id: string, name: string }> | null, chain: { id: string, name: string, type: string, allowance: number, chainId: string, hasOwnEndpoint: boolean, useOracles: boolean, responsePath: string, rpc?: string | null, endpoint?: string | null, healthyValue?: string | null }, host: { id: string, name: string } } };
 
 export type INodesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1369,6 +1369,7 @@ export const NodeDocument = gql`
       name
     }
     basicAuth
+    erroredAt
   }
 }
     `;

--- a/packages/ui/src/types/types.ts
+++ b/packages/ui/src/types/types.ts
@@ -250,6 +250,7 @@ export type INode = {
   conditions: Scalars['String'];
   deltaArray?: Maybe<Array<Maybe<Scalars['Int']>>>;
   dispatch?: Maybe<Scalars['Boolean']>;
+  erroredAt?: Maybe<Scalars['String']>;
   frontend?: Maybe<Scalars['String']>;
   host: IHost;
   id: Scalars['ID'];
@@ -544,7 +545,7 @@ export type INodeQuery = { node: { id: string, backend?: string | null, frontend
 export type INodesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type INodesQuery = { nodes: Array<{ id: string, backend?: string | null, frontend?: string | null, port: number, name: string, server?: string | null, url: string, muted: boolean, status: string, conditions: string, automation?: boolean | null, dispatch?: boolean | null, basicAuth?: string | null, loadBalancers?: Array<{ id: string, name: string }> | null, chain: { id: string, name: string, type: string, allowance: number, chainId: string, hasOwnEndpoint: boolean, useOracles: boolean, responsePath: string, rpc?: string | null, endpoint?: string | null, healthyValue?: string | null }, host: { id: string, name: string } }> };
+export type INodesQuery = { nodes: Array<{ id: string, backend?: string | null, frontend?: string | null, port: number, name: string, server?: string | null, url: string, muted: boolean, status: string, conditions: string, automation?: boolean | null, dispatch?: boolean | null, basicAuth?: string | null, erroredAt?: string | null, loadBalancers?: Array<{ id: string, name: string }> | null, chain: { id: string, name: string, type: string, allowance: number, chainId: string, hasOwnEndpoint: boolean, useOracles: boolean, responsePath: string, rpc?: string | null, endpoint?: string | null, healthyValue?: string | null }, host: { id: string, name: string } }> };
 
 export type ILogsQueryVariables = Exact<{
   input: ILogParams;
@@ -1436,6 +1437,7 @@ export const NodesDocument = gql`
       name
     }
     basicAuth
+    erroredAt
   }
 }
     `;

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './deep-equal';
 export * from './error-utils';
 export * from './modal-helper';
+export * from './parse-seconds';
 export * from './regex-test';
 export * from './snackbar-helper';
 export * from './text-utils';

--- a/packages/ui/src/utils/parse-seconds.ts
+++ b/packages/ui/src/utils/parse-seconds.ts
@@ -1,0 +1,18 @@
+export function parseSeconds(seconds: number): string {
+  const d = Math.floor(seconds / (3600 * 24));
+  const h = Math.floor((seconds % (3600 * 24)) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+
+  const dDisplay = d > 0 ? d + (d === 1 ? ' day, ' : ' days, ') : '';
+  const hDisplay = h > 0 ? h + (h === 1 ? ' hour, ' : ' hours, ') : '';
+  const mDisplay = m > 0 ? m + (m === 1 ? ' minute, ' : ' minutes, ') : '';
+  const sDisplay = s > 0 ? s + (s === 1 ? ' second' : ' seconds') : '';
+  return dDisplay + hDisplay + mDisplay + sDisplay;
+}
+
+export function getSeconds(erroredAt: string): number {
+  const erroredDate = new Date(Number(erroredAt));
+  const seconds = (new Date(Date.now()).getTime() - erroredDate.getTime()) / 1000;
+  return seconds;
+}


### PR DESCRIPTION
This PR adds the ability to display the duration of a particular errorred node, rather than the count of # of times the error has occurred. When the node returns to a health state the timestamp storing the first occurrence of the error is reset.

given the # of different events that can cause the monitor to restart, displaying the count of events was not very useful, whereas displaying the duration of the error is much more valuable.