### PR TITLE
feat: Improved error message display for both occurrence length and message display in alerts and UI

### DIFF
--- a/packages/api/src/queries.graphql
+++ b/packages/api/src/queries.graphql
@@ -207,11 +207,6 @@ query GetServerCount($id: ID!) {
 
 query GetHealthCheck($id: ID!) {
   healthCheck: getHealthCheck(id: $id) {
-    node {
-      status
-      conditions
-      deltaArray
-    }
     height {
       internalHeight
       delta
@@ -223,5 +218,11 @@ query GetHealthCheck($id: ID!) {
       nodeIsAheadOfPeer
       secondsToRecover
     }
+    node {
+      status
+      conditions
+      deltaArray
+    }
+    error
   }
 }

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -88,6 +88,7 @@ const typeDefs = gql`
     height: BlockHeight
     details: HealthResponseDetails
     node: Node
+    error: String
   }
 
   type BlockHeight {

--- a/packages/core/globalConfig.json
+++ b/packages/core/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:35623/","mongoDBName":"jest"}
+{"mongoUri":"mongodb://127.0.0.1:43293/","mongoDBName":"jest"}

--- a/packages/core/src/services/alert/alert.test.ts
+++ b/packages/core/src/services/alert/alert.test.ts
@@ -13,37 +13,38 @@ describe('Alert Service Tests', () => {
         EAlertTypes.TRIGGER,
       );
 
-      expect(messageString).toContain(
-        `Error has been occurring for 1 minute, 15 seconds`,
-      );
+      const [firstOccurrence, elapsed] = messageString.split('\n');
+
+      expect(firstOccurrence).toContain(`First occurrence of this error was`);
+      expect(elapsed).toEqual(`Error has been occurring for 1 minute, 15 seconds.`);
     });
 
-    test('Should return a string for an error event that occurred less than a minute ago', async () => {
-      const lessThanMinuteAgo = new Date(Date.now() - 1000 * 45).toUTCString();
+    test('Should return a string for an error event that occurred for less than two monitor intervals', async () => {
+      const lessThanTwoIntervals = new Date(Date.now() - 1000 * 10 - 1000).toUTCString();
 
       const messageString = alertService['getErrorTimeElapsedString'](
-        lessThanMinuteAgo,
+        lessThanTwoIntervals,
         EAlertTypes.TRIGGER,
       );
 
       const [firstOccurrence, elapsed] = messageString.split('\n');
-      expect(messageString).toContain(`First occurrence of this error was`);
-      expect(firstOccurrence).toBeTruthy();
+
+      expect(firstOccurrence).toContain(`First occurrence of this error was`);
       expect(elapsed).toBeFalsy();
     });
 
     test('Should return a string for a resolved event', async () => {
-      const lessThanMinuteAgo = new Date(Date.now() - 1000 * 90).toUTCString();
+      const lessThanMinuteAgo = new Date(Date.now() - 1000 * 60).toUTCString();
 
       const messageString = alertService['getErrorTimeElapsedString'](
         lessThanMinuteAgo,
         EAlertTypes.RESOLVED,
       );
 
-      expect(messageString).toContain(`First occurrence of this error was`);
-      expect(messageString).toContain(
-        `Error had been occurring for 1 minute, 30 seconds`,
-      );
+      const [firstOccurrence, elapsed] = messageString.split('\n');
+
+      expect(firstOccurrence).toContain(`First occurrence of this error was`);
+      expect(elapsed).toEqual(`Error occurred for 1 minute.`);
     });
   });
 });

--- a/packages/core/src/services/alert/alert.test.ts
+++ b/packages/core/src/services/alert/alert.test.ts
@@ -30,7 +30,7 @@ describe('Alert Service Tests', () => {
       const [firstOccurrence, elapsed] = messageString.split('\n');
 
       expect(firstOccurrence).toContain(`First occurrence of this error was`);
-      expect(elapsed).toBeFalsy();
+      expect(elapsed).toEqual('Error occurred for less than 20 seconds.');
     });
 
     test('Should return a string for a resolved event', async () => {

--- a/packages/core/src/services/alert/service.ts
+++ b/packages/core/src/services/alert/service.ts
@@ -235,7 +235,7 @@ export class Service {
 
   private getErrorTimeElapsedString(erroredAt: string, alertType: EAlertTypes): string {
     const erroredDate = new Date(erroredAt);
-    const firstOccurrence = erroredDate.toUTCString();
+    const firstOccurrence = erroredDate.toUTCString().replace('GMT', 'UTC');
     const seconds = (new Date(Date.now()).getTime() - erroredDate.getTime()) / 1000;
 
     const firstString = `First occurrence of this error was: ${firstOccurrence}.`;

--- a/packages/core/src/services/alert/service.ts
+++ b/packages/core/src/services/alert/service.ts
@@ -237,10 +237,13 @@ export class Service {
     const erroredDate = new Date(erroredAt);
     const firstOccurrence = erroredDate.toUTCString().replace('GMT', 'UTC');
     const seconds = (new Date(Date.now()).getTime() - erroredDate.getTime()) / 1000;
+    const secondsThreshold = (env('MONITOR_INTERVAL') * 2) / 1000;
 
     const firstString = `First occurrence of this error was: ${firstOccurrence}.`;
     let elapsedString = '';
-    if (seconds >= (env('MONITOR_INTERVAL') * 2) / 1000) {
+    if (seconds < secondsThreshold) {
+      elapsedString = `\nError occurred for less than ${secondsThreshold} seconds.`;
+    } else {
       elapsedString =
         alertType === EAlertTypes.RESOLVED
           ? `\nError occurred for ${secondsToUnits(seconds)}.`

--- a/packages/core/src/services/alert/service.ts
+++ b/packages/core/src/services/alert/service.ts
@@ -177,7 +177,7 @@ export class Service {
 
   /* ----- Message String Methods ----- */
   getAlertMessage(
-    { conditions, name, height, details }: IRedisEvent,
+    { conditions, name, height, details, error }: IRedisEvent,
     alertType: EAlertTypes,
     nodesOnline: number,
     nodesTotal: number,
@@ -190,7 +190,8 @@ export class Service {
     const secondsToRecover = details?.secondsToRecover;
 
     const statusStr = `${name} is ${conditions}.`;
-    const countStr = erroredAt
+    const errorMessageStr = error ? error.charAt(0).toUpperCase() + error.slice(1) : '';
+    const errorTimeStr = erroredAt
       ? this.getErrorTimeElapsedString(erroredAt, alertType)
       : '';
     const heightStr = height
@@ -217,7 +218,8 @@ export class Service {
 
     return {
       message: [
-        countStr,
+        errorMessageStr,
+        errorTimeStr,
         heightStr,
         secondsToRecoverStr,
         badOracleStr,
@@ -235,11 +237,16 @@ export class Service {
     const erroredDate = new Date(erroredAt);
     const firstOccurrence = erroredDate.toUTCString();
     const seconds = (new Date(Date.now()).getTime() - erroredDate.getTime()) / 1000;
-    const desc = alertType === EAlertTypes.RESOLVED ? 'had' : 'has';
 
     const firstString = `First occurrence of this error was: ${firstOccurrence}.`;
-    const elapsedString =
-      seconds > 60 ? `\nError ${desc} been occurring for ${secondsToUnits(seconds)}` : '';
+    let elapsedString = '';
+    if (seconds >= (env('MONITOR_INTERVAL') * 2) / 1000) {
+      elapsedString =
+        alertType === EAlertTypes.RESOLVED
+          ? `\nError occurred for ${secondsToUnits(seconds)}.`
+          : `\nError has been occurring for ${secondsToUnits(seconds)}.`;
+    }
+
     return `${firstString}${elapsedString}`;
   }
 

--- a/packages/core/src/services/automation/service.ts
+++ b/packages/core/src/services/automation/service.ts
@@ -368,7 +368,7 @@ export class Service extends BaseService {
     const healthCheckParams = await healthService.getNodeOraclesAndPeers(node);
     const healthCheck = await healthService.checkNodeHealth(healthCheckParams);
 
-    const { status, conditions, height, details } = healthCheck;
+    const { status, conditions, height, details, error } = healthCheck;
     const { status: nodeStatus, conditions: nodeConditions, deltaArray } = node;
 
     if (status !== nodeStatus || conditions !== nodeConditions) {
@@ -376,7 +376,7 @@ export class Service extends BaseService {
     }
 
     const updatedNodeHealth = { status, conditions, deltaArray: deltaArray };
-    return { height, details, node: updatedNodeHealth as INode };
+    return { height, details, node: updatedNodeHealth as INode, error };
   }
 
   /* ----- Rotation Methods ----- */

--- a/packages/core/src/services/event/event.test.ts
+++ b/packages/core/src/services/event/event.test.ts
@@ -89,7 +89,7 @@ describe('Event Service Tests', () => {
       expect(createdNode.name).toEqual('mainnet1/POKT/11');
       expect(title).toEqual('[Resolved] - mainnet1/POKT/11 is HEALTHY.');
       expect(message).toContain('First occurrence of this error was');
-      expect(message).toContain('Error had been occurring for 1 minute, 15 seconds');
+      expect(message).toContain('Error occurred for 1 minute, 15 seconds.');
       expect(message).toContain(
         'Block Height - Internal: 63583 / External: 63583 / Delta: 0',
       );

--- a/packages/core/src/services/health/types.ts
+++ b/packages/core/src/services/health/types.ts
@@ -72,6 +72,7 @@ export interface IHealthCheck {
   node: INode;
   height?: IBlockHeight;
   details?: IHealthResponseDetails;
+  error?: string;
 }
 
 export interface IHealthResponse {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -62,5 +62,5 @@ export function secondsToUnits(seconds: number): string {
   const hDisplay = h > 0 ? h + (h === 1 ? ' hour, ' : ' hours, ') : '';
   const mDisplay = m > 0 ? m + (m === 1 ? ' minute, ' : ' minutes, ') : '';
   const sDisplay = s > 0 ? s + (s === 1 ? ' second' : ' seconds') : '';
-  return dDisplay + hDisplay + mDisplay + sDisplay;
+  return (dDisplay + hDisplay + mDisplay + sDisplay).replace(/,\s*$/, '');
 }

--- a/packages/ui/src/components/Nodes/NodeHealth.tsx
+++ b/packages/ui/src/components/Nodes/NodeHealth.tsx
@@ -5,7 +5,14 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 
 import { INode, IGetHealthCheckQuery, IGetServerCountQuery } from 'types';
-import { formatHeaderCell, getSeconds, numWithCommas, parseSeconds, s } from 'utils';
+import {
+  formatHeaderCell,
+  getSeconds,
+  numWithCommas,
+  parseSeconds,
+  s,
+  capitalizeFirstLetter,
+} from 'utils';
 
 interface NodeHealthProps {
   node: INode;
@@ -22,6 +29,8 @@ export const NodeHealth = ({
   loading,
   haProxyOnline,
 }: NodeHealthProps) => {
+  console.log({ healthCheckData });
+
   const getLastChangedDelta = useCallback((healthCheckData: IGetHealthCheckQuery) => {
     const deltaArray = healthCheckData?.healthCheck?.node?.deltaArray;
     if (!deltaArray?.length) return null;
@@ -189,6 +198,15 @@ export const NodeHealth = ({
               )}`}</Typography>
               <Typography>
                 {healthCheckData.healthCheck.details.badOracles.join(', ')}
+              </Typography>
+            </Box>
+          )}
+
+          {healthCheckData.healthCheck.error && (
+            <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+              <Typography>Error Message</Typography>
+              <Typography>
+                {capitalizeFirstLetter(healthCheckData.healthCheck.error)}
               </Typography>
             </Box>
           )}

--- a/packages/ui/src/components/Nodes/NodeHealth.tsx
+++ b/packages/ui/src/components/Nodes/NodeHealth.tsx
@@ -29,8 +29,6 @@ export const NodeHealth = ({
   loading,
   haProxyOnline,
 }: NodeHealthProps) => {
-  console.log({ healthCheckData });
-
   const getLastChangedDelta = useCallback((healthCheckData: IGetHealthCheckQuery) => {
     const deltaArray = healthCheckData?.healthCheck?.node?.deltaArray;
     if (!deltaArray?.length) return null;

--- a/packages/ui/src/types/types.ts
+++ b/packages/ui/src/types/types.ts
@@ -64,6 +64,7 @@ export type IChainUpdate = {
 
 export type IHealthCheck = {
   details?: Maybe<IHealthResponseDetails>;
+  error?: Maybe<Scalars['String']>;
   height?: Maybe<IBlockHeight>;
   node?: Maybe<INode>;
 };
@@ -602,7 +603,7 @@ export type IGetHealthCheckQueryVariables = Exact<{
 }>;
 
 
-export type IGetHealthCheckQuery = { healthCheck: { node?: { status: string, conditions: string, deltaArray?: Array<number | null> | null } | null, height?: { internalHeight: number, delta?: number | null, externalHeight?: number | null } | null, details?: { noOracle?: boolean | null, badOracles?: Array<string | null> | null, nodeIsAheadOfPeer?: boolean | null, secondsToRecover?: number | null } | null } };
+export type IGetHealthCheckQuery = { healthCheck: { error?: string | null, height?: { internalHeight: number, delta?: number | null, externalHeight?: number | null } | null, details?: { noOracle?: boolean | null, badOracles?: Array<string | null> | null, nodeIsAheadOfPeer?: boolean | null, secondsToRecover?: number | null } | null, node?: { status: string, conditions: string, deltaArray?: Array<number | null> | null } | null } };
 
 
 export const CreateHostDocument = gql`
@@ -1791,11 +1792,6 @@ export type GetServerCountQueryResult = Apollo.QueryResult<IGetServerCountQuery,
 export const GetHealthCheckDocument = gql`
     query GetHealthCheck($id: ID!) {
   healthCheck: getHealthCheck(id: $id) {
-    node {
-      status
-      conditions
-      deltaArray
-    }
     height {
       internalHeight
       delta
@@ -1807,6 +1803,12 @@ export const GetHealthCheckDocument = gql`
       nodeIsAheadOfPeer
       secondsToRecover
     }
+    node {
+      status
+      conditions
+      deltaArray
+    }
+    error
   }
 }
     `;

--- a/packages/ui/src/utils/parse-seconds.ts
+++ b/packages/ui/src/utils/parse-seconds.ts
@@ -8,7 +8,7 @@ export function parseSeconds(seconds: number): string {
   const hDisplay = h > 0 ? h + (h === 1 ? ' hour, ' : ' hours, ') : '';
   const mDisplay = m > 0 ? m + (m === 1 ? ' minute, ' : ' minutes, ') : '';
   const sDisplay = s > 0 ? s + (s === 1 ? ' second' : ' seconds') : '';
-  return dDisplay + hDisplay + mDisplay + sDisplay;
+  return (dDisplay + hDisplay + mDisplay + sDisplay).replace(/,\s*$/, '');
 }
 
 export function getSeconds(erroredAt: string): number {

--- a/packages/ui/src/utils/text-utils.ts
+++ b/packages/ui/src/utils/text-utils.ts
@@ -15,3 +15,7 @@ export const is = (count: number): string => (count === 1 ? 'is' : 'are');
 export const numWithCommas = (number: number | string): string => {
   return new Intl.NumberFormat().format(Number(number));
 };
+
+export function capitalizeFirstLetter(string: string): string {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}


### PR DESCRIPTION
Main thing to check out here is updated handling for when the response contains `rpcResponse.data.error` field (line 74 in the Health Service) to send NO_RESPONSE. 

Previously this field would send NOT_SYNCHRONIZED which I believe was incorrect and was leading to some weird error handling.

Additionally, I added a display of the error message itself in both the UI and alerts, as well as tweaked the display of the error duration in alerts/UI.